### PR TITLE
Add "AWS S3 Support" section to README.md for large size notion backup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ jobs:
           NOTION_FILE_TOKEN: ${{ secrets.NOTION_FILE_TOKEN }}
           NOTION_SPACE_ID: ${{ secrets.NOTION_SPACE_ID }}
           NODE_OPTIONS: "--max-http-header-size 15000"
-
           
       - name: Upload to S3
         if: "${{ env.AWS_ACCESS_KEY_ID != '' }}"


### PR DESCRIPTION
When I backed up my Notion, I encountered the following two errors::

Error1:
Message: "Error: The operation was canceled." 
Reason: There was not enough time to export all pages.
Change: change timeout-minutes value to 120 in the workflow file

Error2: 
Message: "batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access."
Reason: There was not enough LFS storage.
Change: Add "install awscli" and " Upload to S3" jobs to the workflow file
